### PR TITLE
Updated message for when build directory is not a symlink to replace …

### DIFF
--- a/build.activate.kw.inc
+++ b/build.activate.kw.inc
@@ -36,9 +36,10 @@ function drush_kraftwagen_kw_activate_build($build) {
   if (is_dir($path_build) && is_link($path_build)) {
     drush_shell_exec('rm %s', $root . DIRECTORY_SEPARATOR . $dir_build);
   } elseif (is_dir($path_build)) {
-    drush_log(dt('The directory ./build is NOT a symlink.
-                  Please remove the current ./build directory
-                  or move the ./build directory to ./builds/my-old-build'), 'error');
+    drush_log(dt('The directory !build is NOT a symlink.
+                  Please remove the current !build directory
+                  or move the !build directory to ./builds/my-old-build',
+                  array('!build' => $path_build)),'error');
     return drush_set_error(dt('Could not build in a existing directory.'));
   }
 


### PR DESCRIPTION
….build directory to a variable, in case the user changes the name of this folder.

When the directory where kw would create the build was not a link for some reason, the message was always showing the default ./build directory in the message.

`The directory ./build is NOT a symlink. Please remove the current ./build directory or move the ./build directory to ./builds/my-old-build`

This was causing confusion because, in cases when we change the name of that directory to something else (commonly docroot), the message would be still talking about some ./build directory that doesn't even exist.

This pull request fixes this by replacing the ./build piece of text by a variable that shows the full path of the directory that is being used by kw to build the project.
